### PR TITLE
Add sorting by priority on key

### DIFF
--- a/src/component/task_list.rs
+++ b/src/component/task_list.rs
@@ -61,7 +61,11 @@ impl TaskList {
             ),
             HelpAction::new(KeyCode::Char('t'), "t", "Add tags to the task"),
             HelpAction::new(KeyCode::Char('s'), "s", "Toggle task sort by priority"),
-            HelpAction::new(KeyCode::Char('S'), "S", "Toggle task sort by priority (reverse order)"),
+            HelpAction::new(
+                KeyCode::Char('S'),
+                "S",
+                "Toggle task sort by priority (reverse order)",
+            ),
         ]
     }
 }

--- a/src/component/task_list.rs
+++ b/src/component/task_list.rs
@@ -60,6 +60,8 @@ impl TaskList {
                 "Moves the task up on the task list",
             ),
             HelpAction::new(KeyCode::Char('t'), "t", "Add tags to the task"),
+            HelpAction::new(KeyCode::Char('s'), "s", "Toggle task sort by priority"),
+            HelpAction::new(KeyCode::Char('S'), "S", "Toggle task sort by priority (reverse order)"),
         ]
     }
 }

--- a/src/screens/main_screen.rs
+++ b/src/screens/main_screen.rs
@@ -82,12 +82,12 @@ impl DrawableComponent for MainScreenLayer {
                 EventResult::Consumed
             }
             KeyCode::Char('s') => {
-                app.task_store.tasks.sort_by_key(|t| t.priority.clone());
+                app.task_store.tasks.sort_by_key(|t| t.priority);
                 EventResult::Consumed
             }
             KeyCode::Char('S') => {
                 // NOTE: We can be unstable because `reverse()` will change the order anyway
-                app.task_store.tasks.sort_unstable_by_key(|t| t.priority.clone());
+                app.task_store.tasks.sort_unstable_by_key(|t| t.priority);
                 app.task_store.tasks.reverse();
                 EventResult::Consumed
             }

--- a/src/screens/main_screen.rs
+++ b/src/screens/main_screen.rs
@@ -81,6 +81,16 @@ impl DrawableComponent for MainScreenLayer {
                 app.shutdown();
                 EventResult::Consumed
             }
+            KeyCode::Char('s') => {
+                app.task_store.tasks.sort_by_key(|t| t.priority.clone());
+                EventResult::Consumed
+            }
+            KeyCode::Char('S') => {
+                // NOTE: We can be unstable because `reverse()` will change the order anyway
+                app.task_store.tasks.sort_unstable_by_key(|t| t.priority.clone());
+                app.task_store.tasks.reverse();
+                EventResult::Consumed
+            }
             _ => EventResult::Ignored,
         }
     }

--- a/src/task.rs
+++ b/src/task.rs
@@ -79,7 +79,7 @@ impl CompletedTask {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 pub enum Priority {
     None,
     Low,

--- a/src/task.rs
+++ b/src/task.rs
@@ -79,12 +79,12 @@ impl CompletedTask {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 pub enum Priority {
     None,
-    High,
-    Normal,
     Low,
+    Normal,
+    High,
 }
 
 impl Priority {


### PR DESCRIPTION
This PR allows to sort all tasks by priority on a key press (<kbd>s</kbd>) and in reverse order on <kbd>S</kbd>.