### PR TITLE
Make the config more flexible

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -57,11 +57,20 @@ fn open_dialog_or_fuzzy(app: &mut App, title: &str, options: Vec<DialogAction>) 
 pub fn open_help_menu(app: &mut App) {
     // Actions that are universal, should use a table?
     let mut actions: Vec<DialogAction> = vec![
-        DialogAction::new(String::from("1    Change to current task window"), |app| {
-            app.mode = Mode::CurrentTasks;
-        }),
         DialogAction::new(
-            String::from("2    Change to completed task window"),
+            format!(
+                "{: <6}Change to current task window",
+                app.theme.tasks_menu_key.to_string()
+            ),
+            |app| {
+                app.mode = Mode::CurrentTasks;
+            },
+        ),
+        DialogAction::new(
+            format!(
+                "{: <6}Change to completed task window",
+                app.theme.completed_tasks_menu_key.to_string()
+            ),
             |app| {
                 app.mode = Mode::CompletedTasks;
             },
@@ -69,7 +78,7 @@ pub fn open_help_menu(app: &mut App) {
     ];
     for ac in app.mode.available_help_actions() {
         actions.push(DialogAction::new(
-            format!("{}    {}", ac.short_hand, ac.description),
+            format!("{: <6}{}", ac.short_hand, ac.description),
             move |app| app.execute_event(KeyEvent::new(ac.character, KeyModifiers::NONE)),
         ));
     }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,5 +1,5 @@
 use chrono::Local;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyEvent};
 use tui::style::Color;
 
 use std::{cell::RefCell, rc::Rc};
@@ -12,25 +12,33 @@ use crate::{
         message_box::MessageBox,
     },
     error::AppError,
+    key::Key,
     task::CompletedTask,
 };
 
 // Action class maybe?!!
 pub struct HelpAction<'a> {
-    character: KeyCode,
-    short_hand: &'a str,
+    character: Key,
+    short_hand: String,
     description: &'a str,
 }
 
 impl HelpAction<'_> {
-    pub fn new<'a>(
-        character: KeyCode,
-        short_hand: &'a str,
-        description: &'a str,
-    ) -> HelpAction<'a> {
+    pub fn new(character: Key, description: &str) -> HelpAction<'_> {
         HelpAction {
             character,
-            short_hand,
+            short_hand: character.to_string(),
+            description,
+        }
+    }
+    pub fn new_multiple(character: [Key; 2], description: &str) -> HelpAction<'_> {
+        HelpAction {
+            character: character[0],
+            short_hand: itertools::intersperse(
+                character.iter().map(|f| f.to_string()),
+                " ".to_string(),
+            )
+            .collect::<String>(),
             description,
         }
     }
@@ -59,7 +67,7 @@ pub fn open_help_menu(app: &mut App) {
     let mut actions: Vec<DialogAction> = vec![
         DialogAction::new(
             format!(
-                "{: <6}Change to current task window",
+                "{: <15}Change to current task window",
                 app.theme.tasks_menu_key.to_string()
             ),
             |app| {
@@ -68,7 +76,7 @@ pub fn open_help_menu(app: &mut App) {
         ),
         DialogAction::new(
             format!(
-                "{: <6}Change to completed task window",
+                "{: <15}Change to completed task window",
                 app.theme.completed_tasks_menu_key.to_string()
             ),
             |app| {
@@ -76,10 +84,10 @@ pub fn open_help_menu(app: &mut App) {
             },
         ),
     ];
-    for ac in app.mode.available_help_actions() {
+    for ac in app.mode.available_help_actions(&app.theme) {
         actions.push(DialogAction::new(
-            format!("{: <6}{}", ac.short_hand, ac.description),
-            move |app| app.execute_event(KeyEvent::new(ac.character, KeyModifiers::NONE)),
+            format!("{: <15}{}", ac.short_hand, ac.description),
+            move |app| app.execute_event(KeyEvent::new(ac.character.code, ac.character.modifiers)),
         ));
     }
 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,5 +1,5 @@
 use chrono::Local;
-use crossterm::event::{KeyEvent};
+use crossterm::event::KeyEvent;
 use tui::style::Color;
 
 use std::{cell::RefCell, rc::Rc};

--- a/src/app.rs
+++ b/src/app.rs
@@ -131,10 +131,10 @@ impl Default for Mode {
 }
 
 impl Mode {
-    pub fn available_help_actions(&self) -> Vec<HelpAction> {
+    pub fn available_help_actions(&self, theme: &Theme) -> Vec<HelpAction> {
         match self {
-            Mode::CurrentTasks => TaskList::available_actions(),
-            Mode::CompletedTasks => CompletedList::available_actions(),
+            Mode::CurrentTasks => TaskList::available_actions(theme),
+            Mode::CompletedTasks => CompletedList::available_actions(theme),
             Mode::Overlay => vec![],
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,7 +14,7 @@ use crate::{
     component::status_line::StatusLine,
     component::task_list::TaskList,
     draw::DrawableComponent,
-    task::{CompletedTask, Tag, Task},
+    task::{CompletedTask, Tag, Task, Category},
     theme::Theme,
 };
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,7 +14,7 @@ use crate::{
     component::status_line::StatusLine,
     component::task_list::TaskList,
     draw::DrawableComponent,
-    task::{CompletedTask, Tag, Task, Category},
+    task::{CompletedTask, Tag, Task},
     theme::Theme,
 };
 

--- a/src/component/completed_list.rs
+++ b/src/component/completed_list.rs
@@ -1,4 +1,3 @@
-
 use tui::{
     layout::Rect,
     style::{Color, Style},

--- a/src/component/completed_list.rs
+++ b/src/component/completed_list.rs
@@ -1,4 +1,4 @@
-use crossterm::event::KeyCode;
+
 use tui::{
     layout::Rect,
     style::{Color, Style},
@@ -16,6 +16,7 @@ use crate::{
     app::{App, Mode},
     draw::{DrawableComponent, EventResult},
     task::Task,
+    theme::Theme,
     utils,
 };
 
@@ -42,10 +43,9 @@ impl CompletedList {
         self.selected_index.borrow_mut()
     }
 
-    pub fn available_actions() -> Vec<HelpAction<'static>> {
+    pub fn available_actions(theme: &Theme) -> Vec<HelpAction<'static>> {
         vec![HelpAction::new(
-            KeyCode::Char('r'),
-            "r",
+            theme.restore_key,
             "Restores the selected task",
         )]
     }

--- a/src/component/completed_list.rs
+++ b/src/component/completed_list.rs
@@ -121,7 +121,8 @@ impl DrawableComponent for CompletedList {
         let key_code = key_event.code;
 
         let result = utils::handle_key_movement(
-            key_code,
+            &app.theme,
+            key_event,
             &mut self.selected_mut(),
             app.task_store.completed_tasks.len(),
         );

--- a/src/component/completed_list.rs
+++ b/src/component/completed_list.rs
@@ -118,8 +118,6 @@ impl DrawableComponent for CompletedList {
     }
 
     fn key_event(&mut self, app: &mut App, key_event: crossterm::event::KeyEvent) -> EventResult {
-        let key_code = key_event.code;
-
         let result = utils::handle_key_movement(
             &app.theme,
             key_event,
@@ -131,7 +129,7 @@ impl DrawableComponent for CompletedList {
             return result;
         }
 
-        if let KeyCode::Char('r') = key_code {
+        if app.theme.restore_key.is_pressed(key_event) {
             self.restore_task(app);
             return EventResult::Consumed;
         }

--- a/src/component/input/dialog.rs
+++ b/src/component/input/dialog.rs
@@ -69,7 +69,7 @@ impl DrawableComponent for DialogBox {
                 return EventResult::Consumed;
             }
         }
-        utils::handle_key_movement(key_code, &mut self.index, self.options.len());
+        utils::handle_key_movement(&app.theme, key_event, &mut self.index, self.options.len());
         match key_code {
             KeyCode::Enter => {
                 app.pop_layer();

--- a/src/component/input/fuzzy.rs
+++ b/src/component/input/fuzzy.rs
@@ -2,7 +2,6 @@ use crossterm::event::{KeyCode, KeyEvent, MouseEvent, MouseEventKind};
 use itertools::Itertools;
 use tui::{
     layout::{Constraint, Layout, Rect},
-    style::Color,
     text::Line,
     widgets::{Clear, List, ListItem, ListState},
 };
@@ -46,7 +45,7 @@ impl DrawableComponent for FuzzyBox {
                 .collect::<Vec<ListItem>>(),
         )
         .highlight_style(app.theme.highlight_dropdown_style())
-        .block(app.theme.styled_block("", Color::Green));
+        .block(app.theme.styled_block("", app.theme.selected_border_colour));
 
         let mut list_state = ListState::default();
         list_state.select(Some(self.list_index));
@@ -93,14 +92,23 @@ impl DrawableComponent for FuzzyBox {
         let code = key_event.code;
         match code {
             _ if app.theme.move_down_fuzzy.is_pressed(key_event) => {
+                if self.active.is_empty() {
+                    return EventResult::Consumed;
+                }
                 self.list_index = (self.list_index + 1).rem_euclid(self.active.len());
                 EventResult::Consumed
             }
             KeyCode::Down => {
+                if self.active.is_empty() {
+                    return EventResult::Consumed;
+                }
                 self.list_index = (self.list_index + 1).rem_euclid(self.active.len());
                 EventResult::Consumed
             }
             _ if app.theme.move_up_fuzzy.is_pressed(key_event) => {
+                if self.active.is_empty() {
+                    return EventResult::Consumed;
+                }
                 match self.list_index.checked_sub(1) {
                     Some(val) => self.list_index = val,
                     None => self.list_index = self.active.len() - 1,
@@ -108,6 +116,9 @@ impl DrawableComponent for FuzzyBox {
                 EventResult::Consumed
             }
             KeyCode::Up => {
+                if self.active.is_empty() {
+                    return EventResult::Consumed;
+                }
                 match self.list_index.checked_sub(1) {
                     Some(val) => self.list_index = val,
                     None => self.list_index = self.active.len() - 1,

--- a/src/component/input/fuzzy.rs
+++ b/src/component/input/fuzzy.rs
@@ -172,18 +172,6 @@ impl FuzzyBoxBuilder {
         }
     }
 
-    pub fn add_option<F: 'static>(self, name: String, function: F) -> Self
-    where
-        F: FnOnce(&mut App),
-    {
-        self.add_dialog_action(DialogAction::new(name, function))
-    }
-
-    pub fn add_dialog_action(mut self, dialog_action: DialogAction) -> Self {
-        self.options.push(dialog_action);
-        self
-    }
-
     pub fn options(mut self, options: Vec<DialogAction>) -> Self {
         self.options = options;
         self

--- a/src/component/input/fuzzy.rs
+++ b/src/component/input/fuzzy.rs
@@ -92,7 +92,7 @@ impl DrawableComponent for FuzzyBox {
     fn key_event(&mut self, app: &mut App, key_event: KeyEvent) -> EventResult {
         let code = key_event.code;
         match code {
-            KeyCode::Char('n') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+            _ if app.theme.move_down_fuzzy.is_pressed(key_event) => {
                 self.list_index = (self.list_index + 1).rem_euclid(self.active.len());
                 EventResult::Consumed
             }
@@ -100,7 +100,7 @@ impl DrawableComponent for FuzzyBox {
                 self.list_index = (self.list_index + 1).rem_euclid(self.active.len());
                 EventResult::Consumed
             }
-            KeyCode::Char('p') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+            _ if app.theme.move_up_fuzzy.is_pressed(key_event) => {
                 match self.list_index.checked_sub(1) {
                     Some(val) => self.list_index = val,
                     None => self.list_index = self.active.len() - 1,

--- a/src/component/input/fuzzy.rs
+++ b/src/component/input/fuzzy.rs
@@ -30,6 +30,7 @@ pub struct FuzzyBox {
 
 impl FuzzyBox {
     fn generate_rect(&self, rect: Rect) -> Rect {
+        // FIXME: consider using length of options.
         utils::centre_rect(Constraint::Percentage(70), Constraint::Percentage(80), rect)
     }
 }

--- a/src/component/input/fuzzy.rs
+++ b/src/component/input/fuzzy.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
+use crossterm::event::{KeyCode, KeyEvent, MouseEvent, MouseEventKind};
 use itertools::Itertools;
 use tui::{
     layout::{Constraint, Layout, Rect},

--- a/src/component/input/input_box.rs
+++ b/src/component/input/input_box.rs
@@ -60,7 +60,7 @@ impl DrawableComponent for InputBox {
         let boxes = Block::default()
             .borders(Borders::ALL)
             .border_style(Style::default().fg(app.theme.selected_border_colour))
-            .border_type(app.theme.border_style)
+            .border_type(app.theme.border_type)
             .title(self.title.as_ref());
         let box_area = boxes.inner(self.draw_area);
 

--- a/src/component/input/input_box.rs
+++ b/src/component/input/input_box.rs
@@ -60,7 +60,7 @@ impl DrawableComponent for InputBox {
         let boxes = Block::default()
             .borders(Borders::ALL)
             .border_style(Style::default().fg(app.theme.selected_border_colour))
-            .border_type(app.theme.border_style.border_type)
+            .border_type(app.theme.border_style)
             .title(self.title.as_ref());
         let box_area = boxes.inner(self.draw_area);
 

--- a/src/component/message_box.rs
+++ b/src/component/message_box.rs
@@ -85,7 +85,7 @@ impl DrawableComponent for MessageBox {
         let list = list.block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_type(app.theme.border_style.border_type)
+                .border_type(app.theme.border_style)
                 .border_style(style)
                 .title(self.title.as_ref()),
         );

--- a/src/component/message_box.rs
+++ b/src/component/message_box.rs
@@ -85,7 +85,7 @@ impl DrawableComponent for MessageBox {
         let list = list.block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_type(app.theme.border_style)
+                .border_type(app.theme.border_type)
                 .border_style(style)
                 .title(self.title.as_ref()),
         );

--- a/src/component/task_list.rs
+++ b/src/component/task_list.rs
@@ -16,6 +16,7 @@ use crate::{
     actions::{self, HelpAction},
     app::{App, Mode},
     draw::{DrawableComponent, EventResult},
+    theme::KeyBindings,
     utils::{self, handle_mouse_movement},
 };
 
@@ -153,102 +154,107 @@ impl DrawableComponent for TaskList {
         let mut selected_index = self.selected_mut();
 
         // Move this to the actions class
-        if theme.change_priority_key.is_pressed(key_event) {
-            if app.task_store.tasks.is_empty() {
-                return EventResult::Ignored;
+        match KeyBindings::from_event(theme, key_event) {
+            KeyBindings::ChangePriorityKey => {
+                if app.task_store.tasks.is_empty() {
+                    return EventResult::Ignored;
+                }
+
+                let old_task = {
+                    let task = &mut app.task_store.tasks[*selected_index];
+
+                    task.priority = task.priority.next_priority();
+
+                    task.clone()
+                };
+
+                if app.task_store.auto_sort {
+                    app.task_store.sort();
+                }
+
+                *selected_index = app
+                    .task_store
+                    .tasks
+                    .iter()
+                    .position(|t| *t == old_task)
+                    .expect("getting task index after sorting")
+                    .to_owned();
             }
+            KeyBindings::MoveTaskDown => {
+                let tasks_length = app.task_store.tasks.len();
 
-            let old_task = {
-                let task = &mut app.task_store.tasks[*selected_index];
+                if tasks_length == 0 {
+                    return EventResult::Ignored;
+                }
 
-                task.priority = task.priority.next_priority();
+                let new_index = (*selected_index + 1) % tasks_length;
 
-                task.clone()
-            };
+                let task = &app.task_store.tasks[*selected_index];
+                let task_below = &app.task_store.tasks[new_index];
 
-            if app.task_store.auto_sort {
-                app.task_store.sort();
+                if task.priority == task_below.priority || !app.task_store.auto_sort {
+                    let task = app.task_store.tasks.remove(*selected_index);
+
+                    app.task_store.tasks.insert(new_index, task);
+                    *selected_index = new_index;
+                }
             }
+            KeyBindings::MoveTaskUp => {
+                let tasks_length = app.task_store.tasks.len();
 
-            *selected_index = app
-                .task_store
-                .tasks
-                .iter()
-                .position(|t| *t == old_task)
-                .expect("getting task index after sorting")
-                .to_owned();
-        } else if theme.move_task_down.is_pressed(key_event) {
-            let tasks_length = app.task_store.tasks.len();
+                if tasks_length == 0 {
+                    return EventResult::Ignored;
+                }
 
-            if tasks_length == 0 {
-                return EventResult::Ignored;
+                let new_index =
+                    (*selected_index as isize - 1).rem_euclid(tasks_length as isize) as usize;
+
+                let task = &app.task_store.tasks[*selected_index];
+                let task_above = &app.task_store.tasks[new_index];
+
+                if task.priority == task_above.priority || !app.task_store.auto_sort {
+                    let task = app.task_store.tasks.remove(*selected_index);
+
+                    app.task_store.tasks.insert(new_index, task);
+                    *selected_index = new_index;
+                }
             }
-
-            let new_index = (*selected_index + 1) % tasks_length;
-
-            let task = &app.task_store.tasks[*selected_index];
-            let task_below = &app.task_store.tasks[new_index];
-
-            if task.priority == task_below.priority || !app.task_store.auto_sort {
-                let task = app.task_store.tasks.remove(*selected_index);
-
-                app.task_store.tasks.insert(new_index, task);
-                *selected_index = new_index;
+            KeyBindings::DeleteKey => {
+                actions::open_delete_task_menu(app, self.selected_index.clone())
             }
-        } else if theme.move_task_up.is_pressed(key_event) {
-            let tasks_length = app.task_store.tasks.len();
-
-            if tasks_length == 0 {
-                return EventResult::Ignored;
+            KeyBindings::EditKey => {
+                let index = *selected_index;
+                let edit_box = InputBoxBuilder::default()
+                    .title(String::from("Edit the selected task"))
+                    .fill(app.task_store.tasks[*selected_index].title.as_str())
+                    .callback(move |app, word| {
+                        app.task_store.tasks[index].title = word.trim().to_string();
+                        Ok(())
+                    })
+                    .save_mode(app)
+                    .build();
+                app.push_layer(edit_box)
             }
-
-            let new_index =
-                (*selected_index as isize - 1).rem_euclid(tasks_length as isize) as usize;
-
-            let task = &app.task_store.tasks[*selected_index];
-            let task_above = &app.task_store.tasks[new_index];
-
-            if task.priority == task_above.priority || !app.task_store.auto_sort {
-                let task = app.task_store.tasks.remove(*selected_index);
-
-                app.task_store.tasks.insert(new_index, task);
-                *selected_index = new_index;
+            KeyBindings::FlipTag => actions::flip_tag_menu(app, *selected_index),
+            KeyBindings::TagMenu => actions::edit_tag_menu(app, *selected_index),
+            KeyBindings::FlipProgressKey => {
+                if app.task_store.tasks.is_empty() {
+                    return EventResult::Ignored;
+                }
+                app.task_store.tasks[*selected_index].progress =
+                    !app.task_store.tasks[*selected_index].progress;
             }
-        } else if theme.delete_key.is_pressed(key_event) {
-            actions::open_delete_task_menu(app, self.selected_index.clone())
-        } else if theme.edit_key.is_pressed(key_event) {
-            let index = *selected_index;
-            let edit_box = InputBoxBuilder::default()
-                .title(String::from("Edit the selected task"))
-                .fill(app.task_store.tasks[*selected_index].title.as_str())
-                .callback(move |app, word| {
-                    app.task_store.tasks[index].title = word.trim().to_string();
-                    Ok(())
-                })
-                .save_mode(app)
-                .build();
-            app.push_layer(edit_box)
-        } else if theme.flip_tag.is_pressed(key_event) {
-            actions::flip_tag_menu(app, *selected_index)
-        } else if theme.tag_menu.is_pressed(key_event) {
-            actions::edit_tag_menu(app, *selected_index)
-        } else if theme.flip_progress_key.is_pressed(key_event) {
-            if app.task_store.tasks.is_empty() {
-                return EventResult::Ignored;
+            KeyBindings::CompleteKey => actions::complete_task(app, &mut selected_index),
+            _ => {
+                return utils::handle_key_movement(
+                    theme,
+                    key_event,
+                    &mut selected_index,
+                    app.task_store.tasks.len(),
+                );
             }
-            app.task_store.tasks[*selected_index].progress =
-                !app.task_store.tasks[*selected_index].progress;
-        } else if theme.complete_key.is_pressed(key_event) {
-            actions::complete_task(app, &mut selected_index)
-        } else {
-            utils::handle_key_movement(
-                &theme,
-                key_event,
-                &mut selected_index,
-                app.task_store.tasks.len(),
-            );
         }
-        EventResult::Ignored
+        EventResult::Consumed
     }
 
     fn mouse_event(

--- a/src/component/task_list.rs
+++ b/src/component/task_list.rs
@@ -3,7 +3,8 @@ use std::{
     rc::Rc,
 };
 
-use crossterm::event::KeyCode;
+
+
 use tui::{
     layout::Rect,
     style::{Color, Modifier, Style},
@@ -16,7 +17,7 @@ use crate::{
     actions::{self, HelpAction},
     app::{App, Mode},
     draw::{DrawableComponent, EventResult},
-    theme::KeyBindings,
+    theme::{KeyBindings, Theme},
     utils::{self, handle_mouse_movement},
 };
 
@@ -43,37 +44,24 @@ impl TaskList {
         self.selected_index.borrow_mut()
     }
 
-    pub fn available_actions() -> Vec<HelpAction<'static>> {
+    pub fn available_actions(theme: &Theme) -> Vec<HelpAction<'static>> {
         vec![
-            HelpAction::new(KeyCode::Char('a'), "a", "Adds a task"),
-            HelpAction::new(KeyCode::Char('c'), "c", "Completes the selected task"),
-            HelpAction::new(KeyCode::Char('d'), "d", "Delete the selected task"),
-            HelpAction::new(KeyCode::Char('e'), "e", "Edits the selected task"),
-            HelpAction::new(KeyCode::Char('f'), "f", "Flip a tag to the selected task"),
+            HelpAction::new(theme.add_key, "Adds a task"),
+            HelpAction::new(theme.complete_key, "Completes the selected task"),
+            HelpAction::new(theme.delete_key, "Delete the selected task"),
+            HelpAction::new(theme.edit_key, "Edits the selected task"),
+            HelpAction::new(theme.flip_tag, "Flip a tag to the selected task"),
+            HelpAction::new(theme.tag_menu, "Add or remove the tags for this project"),
             HelpAction::new(
-                KeyCode::Char('t'),
-                "t",
-                "Add or remove the tags for this project",
-            ),
-            HelpAction::new(
-                KeyCode::Char('h'),
-                "h",
+                theme.change_priority_key,
                 "Gives selected task lower priority",
             ),
-            HelpAction::new(
-                KeyCode::Char('J'),
-                "J",
-                "Moves the task down on the task list",
-            ),
-            HelpAction::new(
-                KeyCode::Char('K'),
-                "K",
-                "Moves the task up on the task list",
-            ),
-            HelpAction::new(KeyCode::Char('j'), "j", "Moves down one task"),
-            HelpAction::new(KeyCode::Char('k'), "k", "Moves up one task"),
-            HelpAction::new(KeyCode::Char('s'), "s", "Sorts tasks (by priority)"),
-            HelpAction::new(KeyCode::Char('S'), "S", "Toggles automatic task sort"),
+            HelpAction::new(theme.move_task_down, "Moves the task down on the task list"),
+            HelpAction::new(theme.move_task_up, "Moves the task up on the task list"),
+            HelpAction::new_multiple(theme.down_keys, "Moves down one task"),
+            HelpAction::new_multiple(theme.down_keys, "Moves up one task"),
+            HelpAction::new(theme.sort_key, "Sorts tasks (by priority)"),
+            HelpAction::new(theme.enable_autosort_key, "Toggles automatic task sort"),
         ]
     }
 }

--- a/src/component/task_list.rs
+++ b/src/component/task_list.rs
@@ -244,7 +244,8 @@ impl DrawableComponent for TaskList {
             KeyCode::Char('c') => actions::complete_task(app, &mut selected_index),
             _ => {
                 utils::handle_key_movement(
-                    key_code,
+                    &app.theme,
+                    key_event,
                     &mut selected_index,
                     app.task_store.tasks.len(),
                 );

--- a/src/component/task_list.rs
+++ b/src/component/task_list.rs
@@ -234,7 +234,7 @@ impl DrawableComponent for TaskList {
             }
             KeyCode::Char('f') => actions::flip_tag_menu(app, *selected_index),
             KeyCode::Char('t') => actions::edit_tag_menu(app, *selected_index),
-            KeyCode::Enter => {
+            KeyCode::Char(' ') => {
                 if app.task_store.tasks.is_empty() {
                     return EventResult::Ignored;
                 }

--- a/src/component/task_list.rs
+++ b/src/component/task_list.rs
@@ -218,8 +218,10 @@ impl DrawableComponent for TaskList {
                     *selected_index = new_index;
                 }
             }
-            KeyCode::Char('d') => actions::open_delete_task_menu(app, self.selected_index.clone()),
-            KeyCode::Char('e') => {
+            _ if app.theme.delete_key.is_pressed(key_event) => {
+                actions::open_delete_task_menu(app, self.selected_index.clone())
+            }
+            _ if app.theme.edit_key.is_pressed(key_event) => {
                 let index = *selected_index;
                 let edit_box = InputBoxBuilder::default()
                     .title(String::from("Edit the selected task"))
@@ -234,14 +236,16 @@ impl DrawableComponent for TaskList {
             }
             KeyCode::Char('f') => actions::flip_tag_menu(app, *selected_index),
             KeyCode::Char('t') => actions::edit_tag_menu(app, *selected_index),
-            KeyCode::Char(' ') => {
+            _ if app.theme.flip_progress_key.is_pressed(key_event) => {
                 if app.task_store.tasks.is_empty() {
                     return EventResult::Ignored;
                 }
                 app.task_store.tasks[*selected_index].progress =
                     !app.task_store.tasks[*selected_index].progress;
             }
-            KeyCode::Char('c') => actions::complete_task(app, &mut selected_index),
+            _ if app.theme.complete_key.is_pressed(key_event) => {
+                actions::complete_task(app, &mut selected_index)
+            }
             _ => {
                 utils::handle_key_movement(
                     &app.theme,

--- a/src/component/task_list.rs
+++ b/src/component/task_list.rs
@@ -3,8 +3,6 @@ use std::{
     rc::Rc,
 };
 
-
-
 use tui::{
     layout::Rect,
     style::{Color, Modifier, Style},

--- a/src/component/viewer.rs
+++ b/src/component/viewer.rs
@@ -4,7 +4,7 @@ use tui::{
     layout::{Constraint, Rect},
     style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders},
+    widgets::Block,
 };
 
 // A viewer of a task/something
@@ -133,10 +133,7 @@ impl DrawableComponent for Viewer {
     fn draw(&self, app: &App, drawer: &mut Drawer) {
         let theme = &app.theme;
         let draw_area = self.area;
-        let block = Block::default()
-            .title("Task information")
-            .borders(Borders::ALL)
-            .border_type(theme.border_style.border_type);
+        let block = theme.styled_block("Task information", theme.default_border_colour);
 
         match app.mode {
             Mode::CurrentTasks => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -151,7 +151,7 @@ pub fn save_data(theme: &Theme, task_store: &TaskStore) {
     save_to_file(
         dirs::config_local_dir(),
         CONFIG_FILE,
-        || serde_json::to_string(theme),
+        || serde_yaml::to_string(theme),
         "config",
     );
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,8 @@ pub enum AppError {
     JsonError(JsonError),
     #[error("YAML parsing error: {0}")]
     YamlError(YamlError),
+    #[error("Key parsing error: {0}")]
+    InvalidKey(String),
 }
 
 impl From<ParseIntError> for AppError {

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,0 +1,142 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use itertools::Itertools;
+use serde::de::{Deserializer, Error};
+use serde::{Deserialize, Serializer};
+
+use crate::error::AppError;
+
+#[derive(Debug)]
+pub struct Key {
+    pub code: KeyCode,
+    pub modifiers: KeyModifiers,
+}
+
+impl Key {
+    pub fn is_pressed(&self, key_event: KeyEvent) -> bool {
+        key_event.code == self.code && key_event.modifiers.contains(self.modifiers)
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Key {
+    fn deserialize<D>(deserializer: D) -> Result<Key, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = Deserialize::deserialize(deserializer)?;
+        from(&s).map_err(|_| D::Error::custom("Invalid key"))
+    }
+}
+
+impl serde::ser::Serialize for Key {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let modifiers = self
+            .modifiers
+            .iter()
+            .map(|f| match f {
+                KeyModifiers::CONTROL => Ok("ctrl"),
+                KeyModifiers::SHIFT => Ok("shift"),
+                KeyModifiers::ALT => Ok("alt"),
+                KeyModifiers::SUPER => Ok("super"),
+                KeyModifiers::HYPER => Ok("hyper"),
+                KeyModifiers::META => Ok("meta"),
+                _ => Err(serde::ser::Error::custom(NOT_VALID)),
+            })
+            .collect::<Result<Vec<&str>, S::Error>>()?
+            .join("-");
+        serializer.serialize_str(
+            &(if modifiers.is_empty() {
+                String::from("")
+            } else {
+                modifiers + "-"
+            } + &match self.code {
+                KeyCode::Backspace => "backspace".to_string(),
+                KeyCode::Enter => "enter".to_string(),
+                KeyCode::Left => "left".to_string(),
+                KeyCode::Right => "right".to_string(),
+                KeyCode::Up => "up".to_string(),
+                KeyCode::Down => "down".to_string(),
+                KeyCode::Home => "home".to_string(),
+                KeyCode::End => "end".to_string(),
+                KeyCode::PageUp => "pageup".to_string(),
+                KeyCode::PageDown => "pagedown".to_string(),
+                KeyCode::Tab => "tab".to_string(),
+                KeyCode::BackTab => "backtab".to_string(),
+                KeyCode::Delete => "delete".to_string(),
+                KeyCode::Insert => "insert".to_string(),
+                KeyCode::F(num) => format!("f{}", num),
+                KeyCode::Char(' ') => "space".to_string(),
+                KeyCode::Char(c) => c.to_string(),
+                KeyCode::Null => "null".to_string(),
+                KeyCode::Esc => "esc".to_string(),
+                KeyCode::CapsLock => "capslock".to_string(),
+                KeyCode::ScrollLock => "scrolllock".to_string(),
+                KeyCode::NumLock => "numlock".to_string(),
+                KeyCode::PrintScreen => "printscreen".to_string(),
+                KeyCode::Pause => "pause".to_string(),
+                KeyCode::Menu => "menu".to_string(),
+                KeyCode::KeypadBegin => "keypadbegin".to_string(),
+                _ => "Unknown".to_string(),
+            }),
+        )
+    }
+}
+
+const NOT_VALID: &str = "Not a valid key";
+
+fn from(value: &str) -> Result<Key, AppError> {
+    let mut values = value.split('-').collect_vec().into_iter();
+    let code = match values
+        .next_back()
+        .ok_or_else(|| AppError::InvalidKey("Empty key".to_string()))?
+    {
+        "backspace" => KeyCode::Backspace,
+        "enter" => KeyCode::Enter,
+        "left" => KeyCode::Left,
+        "right" => KeyCode::Right,
+        "up" => KeyCode::Up,
+        "down" => KeyCode::Down,
+        "home" => KeyCode::Home,
+        "end" => KeyCode::End,
+        "pageup" => KeyCode::PageUp,
+        "pagedown" => KeyCode::PageDown,
+        "tab" => KeyCode::Tab,
+        "backtab" => KeyCode::BackTab,
+        "delete" => KeyCode::Delete,
+        "insert" => KeyCode::Insert,
+        "null" => KeyCode::Null,
+        "esc" => KeyCode::Esc,
+        "capslock" => KeyCode::CapsLock,
+        "scrolllock" => KeyCode::ScrollLock,
+        "numlock" => KeyCode::NumLock,
+        "printscreen" => KeyCode::PrintScreen,
+        "pause" => KeyCode::Pause,
+        "menu" => KeyCode::Menu,
+        "keypadbegin" => KeyCode::KeypadBegin,
+        "space" => KeyCode::Char(' '),
+        a if a.starts_with('f') && a.len() > 1 => KeyCode::F(
+            a.strip_prefix('f')
+                .ok_or_else(|| AppError::InvalidKey(NOT_VALID.to_string()))?
+                .parse::<u8>()?,
+        ),
+        a => KeyCode::Char(
+            a.chars()
+                .next()
+                .ok_or_else(|| AppError::InvalidKey(NOT_VALID.to_string()))?,
+        ),
+    };
+    let modifiers = values
+        .map(|f| match f.to_lowercase().as_str() {
+            "shift" => Ok(KeyModifiers::SHIFT),
+            "control" | "ctrl" => Ok(KeyModifiers::CONTROL),
+            "alt" => Ok(KeyModifiers::ALT),
+            "super" => Ok(KeyModifiers::SUPER),
+            "hyper" => Ok(KeyModifiers::HYPER),
+            "meta" => Ok(KeyModifiers::META),
+            _ => Err(AppError::InvalidKey(NOT_VALID.to_string())),
+        })
+        .fold_ok(KeyModifiers::NONE, |f, acc| f.union(acc))?;
+    Ok(Key { code, modifiers })
+}

--- a/src/key.rs
+++ b/src/key.rs
@@ -15,6 +15,17 @@ impl Key {
     pub fn is_pressed(&self, key_event: KeyEvent) -> bool {
         key_event.code == self.code && key_event.modifiers.contains(self.modifiers)
     }
+
+    pub fn new(code: KeyCode, modifiers: KeyModifiers) -> Key {
+        Key { code, modifiers }
+    }
+
+    pub fn from_event(event: KeyEvent) -> Key {
+        Key {
+            code: event.code,
+            modifiers: event.modifiers,
+        }
+    }
 }
 
 impl<'de> serde::de::Deserialize<'de> for Key {

--- a/src/key.rs
+++ b/src/key.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serializer};
 
 use crate::error::AppError;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Key {
     pub code: KeyCode,
     pub modifiers: KeyModifiers,

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.show_cursor()?;
 
     config::save_data(&app.theme, &app.task_store);
-    println!("{:?}", app.theme.up_key);
 
     if let Err(err) = result {
         eprintln!("{:?}", err);

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.show_cursor()?;
 
     config::save_data(&app.theme, &app.task_store);
+    println!("{:?}", app.theme.up_key);
 
     if let Err(err) = result {
         eprintln!("{:?}", err);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod component;
 mod config;
 mod draw;
 mod error;
+pub mod key;
 mod logger;
 mod screens;
 mod task;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod component;
 mod config;
 mod draw;
 mod error;
-pub mod key;
+mod key;
 mod logger;
 mod screens;
 mod task;

--- a/src/screens/main_screen.rs
+++ b/src/screens/main_screen.rs
@@ -4,16 +4,14 @@ use crate::{
     actions,
     app::{App, Mode},
     component::{
-        completed_list::CompletedList,
-        input::{fuzzy::FuzzyBoxBuilder, input_box::InputBoxBuilder},
-        task_list::TaskList,
+        completed_list::CompletedList, input::input_box::InputBoxBuilder, task_list::TaskList,
         viewer::Viewer,
     },
     draw::{DrawableComponent, Drawer, EventResult},
     task::Task,
     utils,
 };
-use crossterm::event::{KeyCode, MouseEvent};
+use crossterm::event::MouseEvent;
 use tui::layout::{Constraint, Direction, Layout, Rect};
 
 const MINIMUM_SCREEN: u16 = 100;
@@ -59,63 +57,41 @@ impl DrawableComponent for MainScreenLayer {
         }
 
         // Global keybindings
-        match key_event.code {
-            _ if app.theme.add_key.is_pressed(key_event) => {
-                let add_input_dialog = InputBoxBuilder::default()
-                    .title(String::from("Add a task"))
-                    .callback(move |app, word| {
-                        app.task_store
-                            .add_task(Task::from_string(word.trim().to_string()));
+        return if app.theme.add_key.is_pressed(key_event) {
+            let add_input_dialog = InputBoxBuilder::default()
+                .title(String::from("Add a task"))
+                .callback(move |app, word| {
+                    app.task_store
+                        .add_task(Task::from_string(word.trim().to_string()));
 
-                        Ok(())
-                    })
-                    .save_mode(app)
-                    .build();
-                app.push_layer(add_input_dialog);
-                EventResult::Consumed
-            }
-            KeyCode::Char('1') => {
-                app.mode = Mode::CurrentTasks;
-                EventResult::Consumed
-            }
-            KeyCode::Char('m') => {
-                let fuzzy = FuzzyBoxBuilder::default()
-                    .title("Test".to_string())
-                    .save_mode(app)
-                    .add_option("Test".to_string(), |app| app.println(String::from("First")))
-                    .add_option("Not test".to_string(), |app| {
-                        app.println(String::from("Second"))
-                    })
-                    .add_option("This is another option".to_string(), |app| {
-                        app.println(String::from("Third"))
-                    })
-                    .build();
-                app.push_layer(fuzzy);
-                EventResult::Consumed
-            }
-            KeyCode::Char('2') => {
-                app.mode = Mode::CompletedTasks;
-                EventResult::Consumed
-            }
-            KeyCode::Char('x') => {
-                actions::open_help_menu(app);
-                EventResult::Consumed
-            }
-            KeyCode::Char('q') => {
-                app.shutdown();
-                EventResult::Consumed
-            }
-            KeyCode::Char('s') => {
-                app.task_store.sort();
-                EventResult::Consumed
-            }
-            KeyCode::Char('S') => {
-                app.task_store.auto_sort = !app.task_store.auto_sort;
-                app.task_store.sort();
-                EventResult::Consumed
-            }
-            _ => EventResult::Ignored,
-        }
+                    Ok(())
+                })
+                .save_mode(app)
+                .build();
+            app.push_layer(add_input_dialog);
+            EventResult::Consumed
+        } else if app.theme.tasks_menu_key.is_pressed(key_event) {
+            app.mode = Mode::CurrentTasks;
+            EventResult::Consumed
+        } else if app.theme.completed_tasks_menu_key.is_pressed(key_event) {
+            app.mode = Mode::CompletedTasks;
+            EventResult::Consumed
+        } else if app.theme.open_help_key.is_pressed(key_event) {
+            actions::open_help_menu(app);
+            EventResult::Consumed
+        } else if app.theme.quit_key.is_pressed(key_event) {
+            app.shutdown();
+            EventResult::Consumed
+        } else if app.theme.sort_key.is_pressed(key_event) {
+            app.task_store.sort();
+            EventResult::Consumed
+        } else if app.theme.enable_autosort_key.is_pressed(key_event) {
+            app.task_store.auto_sort = !app.task_store.auto_sort;
+            app.task_store.sort();
+            EventResult::Consumed
+        } else {
+            EventResult::Ignored
+        };
     }
 
     fn mouse_event(

--- a/src/screens/main_screen.rs
+++ b/src/screens/main_screen.rs
@@ -60,7 +60,7 @@ impl DrawableComponent for MainScreenLayer {
 
         // Global keybindings
         match key_event.code {
-            KeyCode::Char('a') => {
+            _ if app.theme.add_key.is_pressed(key_event) => {
                 let add_input_dialog = InputBoxBuilder::default()
                     .title(String::from("Add a task"))
                     .callback(move |app, word| {

--- a/src/screens/main_screen.rs
+++ b/src/screens/main_screen.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     draw::{DrawableComponent, Drawer, EventResult},
     task::Task,
+    theme::KeyBindings,
     utils,
 };
 use crossterm::event::MouseEvent;
@@ -57,40 +58,47 @@ impl DrawableComponent for MainScreenLayer {
         }
 
         // Global keybindings
-        return if app.theme.add_key.is_pressed(key_event) {
-            let add_input_dialog = InputBoxBuilder::default()
-                .title(String::from("Add a task"))
-                .callback(move |app, word| {
-                    app.task_store
-                        .add_task(Task::from_string(word.trim().to_string()));
+        return match KeyBindings::from_event(&app.theme, key_event) {
+            KeyBindings::AddKey => {
+                let add_input_dialog = InputBoxBuilder::default()
+                    .title(String::from("Add a task"))
+                    .callback(move |app, word| {
+                        app.task_store
+                            .add_task(Task::from_string(word.trim().to_string()));
 
-                    Ok(())
-                })
-                .save_mode(app)
-                .build();
-            app.push_layer(add_input_dialog);
-            EventResult::Consumed
-        } else if app.theme.tasks_menu_key.is_pressed(key_event) {
-            app.mode = Mode::CurrentTasks;
-            EventResult::Consumed
-        } else if app.theme.completed_tasks_menu_key.is_pressed(key_event) {
-            app.mode = Mode::CompletedTasks;
-            EventResult::Consumed
-        } else if app.theme.open_help_key.is_pressed(key_event) {
-            actions::open_help_menu(app);
-            EventResult::Consumed
-        } else if app.theme.quit_key.is_pressed(key_event) {
-            app.shutdown();
-            EventResult::Consumed
-        } else if app.theme.sort_key.is_pressed(key_event) {
-            app.task_store.sort();
-            EventResult::Consumed
-        } else if app.theme.enable_autosort_key.is_pressed(key_event) {
-            app.task_store.auto_sort = !app.task_store.auto_sort;
-            app.task_store.sort();
-            EventResult::Consumed
-        } else {
-            EventResult::Ignored
+                        Ok(())
+                    })
+                    .save_mode(app)
+                    .build();
+                app.push_layer(add_input_dialog);
+                EventResult::Consumed
+            }
+            KeyBindings::TasksMenuKey => {
+                app.mode = Mode::CurrentTasks;
+                EventResult::Consumed
+            }
+            KeyBindings::CompletedTasksMenuKey => {
+                app.mode = Mode::CompletedTasks;
+                EventResult::Consumed
+            }
+            KeyBindings::OpenHelpKey => {
+                actions::open_help_menu(app);
+                EventResult::Consumed
+            }
+            KeyBindings::QuitKey => {
+                app.shutdown();
+                EventResult::Consumed
+            }
+            KeyBindings::SortKey => {
+                app.task_store.sort();
+                EventResult::Consumed
+            }
+            KeyBindings::EnableAutosortKey => {
+                app.task_store.auto_sort = !app.task_store.auto_sort;
+                app.task_store.sort();
+                EventResult::Consumed
+            }
+            _ => EventResult::Ignored,
         };
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -36,6 +36,7 @@ pub struct Theme {
     pub flip_progress_key: Key,
     pub edit_key: Key,
     pub delete_key: Key,
+    pub add_key: Key,
 
     #[serde(with = "border_parser")]
     pub border_style: BorderType,
@@ -52,57 +53,22 @@ impl Default for Theme {
             low_priority_colour: Color::Rgb(0, 0, 0),
             use_fuzzy: true,
             up_keys: [
-                Key {
-                    code: KeyCode::Char('k'),
-                    modifiers: KeyModifiers::NONE,
-                },
-                Key {
-                    code: KeyCode::Up,
-                    modifiers: KeyModifiers::NONE,
-                },
+                Key::new(KeyCode::Char('k'), KeyModifiers::NONE),
+                Key::new(KeyCode::Up, KeyModifiers::NONE),
             ],
             down_keys: [
-                Key {
-                    code: KeyCode::Char('j'),
-                    modifiers: KeyModifiers::NONE,
-                },
-                Key {
-                    code: KeyCode::Down,
-                    modifiers: KeyModifiers::NONE,
-                },
+                Key::new(KeyCode::Char('j'), KeyModifiers::NONE),
+                Key::new(KeyCode::Down, KeyModifiers::NONE),
             ],
-            move_up_fuzzy: Key {
-                code: KeyCode::Char('p'),
-                modifiers: KeyModifiers::CONTROL,
-            },
-            move_down_fuzzy: Key {
-                code: KeyCode::Char('n'),
-                modifiers: KeyModifiers::CONTROL,
-            },
-            move_top: Key {
-                code: KeyCode::Char('g'),
-                modifiers: KeyModifiers::NONE,
-            },
-            move_bottom: Key {
-                code: KeyCode::Char('G'),
-                modifiers: KeyModifiers::NONE,
-            },
-            complete_key: Key {
-                code: KeyCode::Char('c'),
-                modifiers: KeyModifiers::NONE,
-            },
-            flip_progress_key: Key {
-                code: KeyCode::Char(' '),
-                modifiers: KeyModifiers::NONE,
-            },
-            edit_key: Key {
-                code: KeyCode::Char('e'),
-                modifiers: KeyModifiers::NONE,
-            },
-            delete_key: Key {
-                code: KeyCode::Char('d'),
-                modifiers: KeyModifiers::NONE,
-            },
+            move_up_fuzzy: Key::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+            move_down_fuzzy: Key::new(KeyCode::Char('n'), KeyModifiers::CONTROL),
+            move_top: Key::new(KeyCode::Char('g'), KeyModifiers::NONE),
+            move_bottom: Key::new(KeyCode::Char('G'), KeyModifiers::NONE),
+            complete_key: Key::new(KeyCode::Char('c'), KeyModifiers::NONE),
+            flip_progress_key: Key::new(KeyCode::Char(' '), KeyModifiers::NONE),
+            edit_key: Key::new(KeyCode::Char('e'), KeyModifiers::NONE),
+            delete_key: Key::new(KeyCode::Char('d'), KeyModifiers::NONE),
+            add_key: Key::new(KeyCode::Char('a'), KeyModifiers::NONE),
             border_style: BorderType::Plain,
         }
     }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{KeyCode, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use serde::{Deserialize, Serialize};
 use tui::{
@@ -165,5 +165,115 @@ mod border_parser {
             "quadrantoutside" => Ok(BorderType::QuadrantOutside),
             _ => Err(serde::de::Error::custom("Test")),
         }
+    }
+}
+
+pub enum KeyBindings {
+    UpKeys,
+    DownKeys,
+    MoveTaskUp,
+    MoveTaskDown,
+    MoveUpFuzzy,
+    MoveDownFuzzy,
+    MoveTop,
+    MoveBottom,
+
+    CompleteKey,
+    FlipProgressKey,
+    EditKey,
+    DeleteKey,
+    AddKey,
+    ChangePriorityKey,
+    FlipTag,
+    RestoreKey,
+
+    TasksMenuKey,
+    CompletedTasksMenuKey,
+    TagMenu,
+    OpenHelpKey,
+    QuitKey,
+
+    EnableAutosortKey,
+    SortKey,
+
+    None,
+}
+
+impl KeyBindings {
+    pub fn from_event(theme: &Theme, event: KeyEvent) -> KeyBindings {
+        if theme.up_keys.iter().any(|f| f.is_pressed(event)) {
+            return KeyBindings::UpKeys;
+        }
+        if theme.down_keys.iter().any(|f| f.is_pressed(event)) {
+            return KeyBindings::DownKeys;
+        }
+        if theme.move_task_up.is_pressed(event) {
+            return KeyBindings::MoveTaskUp;
+        }
+        if theme.move_task_down.is_pressed(event) {
+            return KeyBindings::MoveTaskDown;
+        }
+        if theme.move_up_fuzzy.is_pressed(event) {
+            return KeyBindings::MoveUpFuzzy;
+        }
+        if theme.move_down_fuzzy.is_pressed(event) {
+            return KeyBindings::MoveDownFuzzy;
+        }
+        if theme.move_top.is_pressed(event) {
+            return KeyBindings::MoveTop;
+        }
+        if theme.move_bottom.is_pressed(event) {
+            return KeyBindings::MoveBottom;
+        }
+
+        if theme.complete_key.is_pressed(event) {
+            return KeyBindings::CompleteKey;
+        }
+        if theme.flip_progress_key.is_pressed(event) {
+            return KeyBindings::FlipProgressKey;
+        }
+        if theme.edit_key.is_pressed(event) {
+            return KeyBindings::EditKey;
+        }
+        if theme.delete_key.is_pressed(event) {
+            return KeyBindings::DeleteKey;
+        }
+        if theme.add_key.is_pressed(event) {
+            return KeyBindings::AddKey;
+        }
+        if theme.change_priority_key.is_pressed(event) {
+            return KeyBindings::ChangePriorityKey;
+        }
+        if theme.flip_tag.is_pressed(event) {
+            return KeyBindings::FlipTag;
+        }
+        if theme.restore_key.is_pressed(event) {
+            return KeyBindings::RestoreKey;
+        }
+
+        if theme.tasks_menu_key.is_pressed(event) {
+            return KeyBindings::TasksMenuKey;
+        }
+        if theme.completed_tasks_menu_key.is_pressed(event) {
+            return KeyBindings::CompletedTasksMenuKey;
+        }
+        if theme.tag_menu.is_pressed(event) {
+            return KeyBindings::TagMenu;
+        }
+        if theme.open_help_key.is_pressed(event) {
+            return KeyBindings::OpenHelpKey;
+        }
+        if theme.quit_key.is_pressed(event) {
+            return KeyBindings::QuitKey;
+        }
+
+        if theme.enable_autosort_key.is_pressed(event) {
+            return KeyBindings::EnableAutosortKey;
+        }
+        if theme.sort_key.is_pressed(event) {
+            return KeyBindings::SortKey;
+        }
+
+        KeyBindings::None
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,8 +1,13 @@
-use serde::{Deserialize, Serialize};
+use crossterm::event::{KeyCode, KeyModifiers};
+use itertools::Itertools;
+use serde::de::{Deserializer, Error, Unexpected};
+use serde::{Deserialize, Serialize, Serializer};
 use tui::{
     style::{Color, Modifier, Style},
     widgets::{Block, BorderType, Borders},
 };
+
+use crate::error::AppError;
 
 #[derive(Deserialize, Serialize)]
 #[serde(default)]
@@ -15,6 +20,7 @@ pub struct Theme {
     pub low_priority_colour: Color,
 
     pub use_fuzzy: bool,
+    pub up_key: Key,
 
     #[serde(skip_serializing, skip_deserializing)]
     pub border_style: BorderStyle,
@@ -31,6 +37,10 @@ impl Default for Theme {
             low_priority_colour: Color::Green,
             use_fuzzy: true,
             border_style: BorderStyle::default(),
+            up_key: Key {
+                code: KeyCode::Char('u'),
+                modifiers: KeyModifiers::SHIFT.union(KeyModifiers::CONTROL),
+            },
         }
     }
 }
@@ -61,4 +71,133 @@ impl Default for BorderStyle {
             border_type: BorderType::Plain,
         }
     }
+}
+
+#[derive(Debug)]
+pub struct Key {
+    code: KeyCode,
+    modifiers: KeyModifiers,
+}
+
+impl<'de> serde::de::Deserialize<'de> for Key {
+    fn deserialize<D>(deserializer: D) -> Result<Key, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = Deserialize::deserialize(deserializer)?;
+        from(&s).map_err(|_| D::Error::custom("Invalid key"))
+    }
+}
+
+impl<'de> serde::ser::Serialize for Key {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(
+            &(self
+                .modifiers
+                .iter()
+                .map(|f| match f {
+                    KeyModifiers::CONTROL => Ok("ctrl"),
+                    KeyModifiers::SHIFT => Ok("shift"),
+                    KeyModifiers::ALT => Ok("alt"),
+                    KeyModifiers::SUPER => Ok("super"),
+                    KeyModifiers::HYPER => Ok("hyper"),
+                    KeyModifiers::META => Ok("meta"),
+                    _ => Err(serde::ser::Error::custom(NOT_VALID)),
+                })
+                .collect::<Result<Vec<&str>, S::Error>>()?
+                .join("-")
+                + "-"
+                + &match self.code {
+                    KeyCode::Backspace => "backspace".to_string(),
+                    KeyCode::Enter => "enter".to_string(),
+                    KeyCode::Left => "left".to_string(),
+                    KeyCode::Right => "right".to_string(),
+                    KeyCode::Up => "up".to_string(),
+                    KeyCode::Down => "down".to_string(),
+                    KeyCode::Home => "home".to_string(),
+                    KeyCode::End => "end".to_string(),
+                    KeyCode::PageUp => "pageup".to_string(),
+                    KeyCode::PageDown => "pagedown".to_string(),
+                    KeyCode::Tab => "tab".to_string(),
+                    KeyCode::BackTab => "backtab".to_string(),
+                    KeyCode::Delete => "delete".to_string(),
+                    KeyCode::Insert => "insert".to_string(),
+                    KeyCode::F(num) => format!("f{}", num),
+                    KeyCode::Char(' ') => "space".to_string(),
+                    KeyCode::Char(c) => c.to_string(),
+                    KeyCode::Null => "null".to_string(),
+                    KeyCode::Esc => "esc".to_string(),
+                    KeyCode::CapsLock => "capslock".to_string(),
+                    KeyCode::ScrollLock => "scrolllock".to_string(),
+                    KeyCode::NumLock => "numlock".to_string(),
+                    KeyCode::PrintScreen => "printscreen".to_string(),
+                    KeyCode::Pause => "pause".to_string(),
+                    KeyCode::Menu => "menu".to_string(),
+                    KeyCode::KeypadBegin => "keypadbegin".to_string(),
+                    _ => "Unknown".to_string(),
+                }),
+        )
+    }
+}
+
+const NOT_VALID: &str = "Not a valid key";
+
+fn from(value: &str) -> Result<Key, AppError> {
+    let mut values = value.split("-").collect_vec().into_iter();
+    let code = match values
+        .next_back()
+        .ok_or_else(|| AppError::InvalidKey("Empty key".to_string()))?
+        .to_lowercase()
+        .as_str()
+    {
+        "backspace" => KeyCode::Backspace,
+        "enter" => KeyCode::Enter,
+        "left" => KeyCode::Left,
+        "right" => KeyCode::Right,
+        "up" => KeyCode::Up,
+        "down" => KeyCode::Down,
+        "home" => KeyCode::Home,
+        "end" => KeyCode::End,
+        "pageup" => KeyCode::PageUp,
+        "pagedown" => KeyCode::PageDown,
+        "tab" => KeyCode::Tab,
+        "backtab" => KeyCode::BackTab,
+        "delete" => KeyCode::Delete,
+        "insert" => KeyCode::Insert,
+        "null" => KeyCode::Null,
+        "esc" => KeyCode::Esc,
+        "capslock" => KeyCode::CapsLock,
+        "scrolllock" => KeyCode::ScrollLock,
+        "numlock" => KeyCode::NumLock,
+        "printscreen" => KeyCode::PrintScreen,
+        "pause" => KeyCode::Pause,
+        "menu" => KeyCode::Menu,
+        "keypadbegin" => KeyCode::KeypadBegin,
+        "space" => KeyCode::Char(' '),
+        a if a.starts_with('f') && a.len() > 1 => KeyCode::F(
+            a.strip_prefix('f')
+                .ok_or_else(|| AppError::InvalidKey(NOT_VALID.to_string()))?
+                .parse::<u8>()?,
+        ),
+        a => KeyCode::Char(
+            a.chars()
+                .next()
+                .ok_or_else(|| AppError::InvalidKey(NOT_VALID.to_string()))?,
+        ),
+    };
+    let modifiers = values
+        .map(|f| match f.to_lowercase().as_str() {
+            "shift" => Ok(KeyModifiers::SHIFT),
+            "control" | "ctrl" => Ok(KeyModifiers::CONTROL),
+            "alt" => Ok(KeyModifiers::ALT),
+            "super" => Ok(KeyModifiers::SUPER),
+            "hyper" => Ok(KeyModifiers::HYPER),
+            "meta" => Ok(KeyModifiers::META),
+            _ => Err(AppError::InvalidKey(NOT_VALID.to_string())),
+        })
+        .fold_ok(KeyModifiers::NONE, |f, acc| f.union(acc))?;
+    Ok(Key { code, modifiers })
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -53,7 +53,7 @@ pub struct Theme {
     pub tag_menu: Key,
 
     #[serde(with = "border_parser")]
-    pub border_style: BorderType,
+    pub border_type: BorderType,
 }
 
 impl Default for Theme {
@@ -64,7 +64,7 @@ impl Default for Theme {
             selected_task_colour: Color::LightBlue,
             high_priority_colour: Color::Red,
             normal_priority_colour: Color::LightYellow,
-            low_priority_colour: Color::Rgb(0, 0, 0),
+            low_priority_colour: Color::Green,
             use_fuzzy: true,
             up_keys: [
                 Key::new(KeyCode::Char('k'), KeyModifiers::NONE),
@@ -99,7 +99,7 @@ impl Default for Theme {
             enable_autosort_key: Key::new(KeyCode::Char('S'), KeyModifiers::NONE),
             sort_key: Key::new(KeyCode::Char('s'), KeyModifiers::NONE),
 
-            border_style: BorderType::Plain,
+            border_type: BorderType::Plain,
         }
     }
 }
@@ -114,7 +114,7 @@ impl Theme {
     pub fn styled_block<'a>(&self, title: &'a str, border_color: Color) -> Block<'a> {
         Block::default()
             .borders(Borders::ALL)
-            .border_type(self.border_style)
+            .border_type(self.border_type)
             .title(title)
             .border_style(Style::default().fg(border_color))
     }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -31,12 +31,26 @@ pub struct Theme {
     pub move_down_fuzzy: Key,
     pub move_top: Key,
     pub move_bottom: Key,
+    pub move_task_up: Key,
+    pub move_task_down: Key,
 
     pub complete_key: Key,
-    pub flip_progress_key: Key,
     pub edit_key: Key,
     pub delete_key: Key,
     pub add_key: Key,
+    pub flip_progress_key: Key,
+    pub change_priority_key: Key,
+    pub restore_key: Key,
+    pub flip_tag: Key,
+
+    pub tasks_menu_key: Key,
+    pub completed_tasks_menu_key: Key,
+    pub open_help_key: Key,
+    pub quit_key: Key,
+
+    pub sort_key: Key,
+    pub enable_autosort_key: Key,
+    pub tag_menu: Key,
 
     #[serde(with = "border_parser")]
     pub border_style: BorderType,
@@ -60,15 +74,31 @@ impl Default for Theme {
                 Key::new(KeyCode::Char('j'), KeyModifiers::NONE),
                 Key::new(KeyCode::Down, KeyModifiers::NONE),
             ],
+            move_task_up: Key::new(KeyCode::Char('K'), KeyModifiers::NONE),
+            move_task_down: Key::new(KeyCode::Char('J'), KeyModifiers::NONE),
             move_up_fuzzy: Key::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
             move_down_fuzzy: Key::new(KeyCode::Char('n'), KeyModifiers::CONTROL),
             move_top: Key::new(KeyCode::Char('g'), KeyModifiers::NONE),
             move_bottom: Key::new(KeyCode::Char('G'), KeyModifiers::NONE),
+
             complete_key: Key::new(KeyCode::Char('c'), KeyModifiers::NONE),
             flip_progress_key: Key::new(KeyCode::Char(' '), KeyModifiers::NONE),
             edit_key: Key::new(KeyCode::Char('e'), KeyModifiers::NONE),
             delete_key: Key::new(KeyCode::Char('d'), KeyModifiers::NONE),
             add_key: Key::new(KeyCode::Char('a'), KeyModifiers::NONE),
+            change_priority_key: Key::new(KeyCode::Char('h'), KeyModifiers::NONE),
+            flip_tag: Key::new(KeyCode::Char('f'), KeyModifiers::NONE),
+            restore_key: Key::new(KeyCode::Char('r'), KeyModifiers::NONE),
+
+            tasks_menu_key: Key::new(KeyCode::Char('1'), KeyModifiers::NONE),
+            completed_tasks_menu_key: Key::new(KeyCode::Char('2'), KeyModifiers::NONE),
+            tag_menu: Key::new(KeyCode::Char('t'), KeyModifiers::NONE),
+            open_help_key: Key::new(KeyCode::Char('x'), KeyModifiers::NONE),
+            quit_key: Key::new(KeyCode::Char('q'), KeyModifiers::NONE),
+
+            enable_autosort_key: Key::new(KeyCode::Char('S'), KeyModifiers::NONE),
+            sort_key: Key::new(KeyCode::Char('s'), KeyModifiers::NONE),
+
             border_style: BorderType::Plain,
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -100,6 +100,9 @@ pub fn handle_mouse_movement(
     index: &mut usize,
     MouseEvent { row, kind, .. }: crossterm::event::MouseEvent,
 ) -> EventResult {
+    if max_items == 0 {
+        return EventResult::Consumed;
+    }
     let offset = row - area.y;
     if let MouseEventKind::ScrollUp = kind {
         if *index != 0 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -166,7 +166,7 @@ pub(crate) mod ui {
         Block::default()
             .title(title)
             .borders(Borders::ALL)
-            .border_type(app.theme.border_style)
+            .border_type(app.theme.border_type)
             .border_style(Style::default().fg(border_colour))
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,7 +3,7 @@ use tui::layout::{Constraint, Direction, Layout, Rect};
 
 use std::usize;
 
-use crate::theme::Theme;
+use crate::theme::{KeyBindings, Theme};
 use crate::{
     app::{App, Mode},
     draw::EventResult,
@@ -62,30 +62,34 @@ pub fn handle_key_movement(
     index: &mut usize,
     max_items: usize,
 ) -> EventResult {
-    return if theme.move_top.is_pressed(key_event) {
-        *index = 0;
-        EventResult::Consumed
-    } else if theme.move_bottom.is_pressed(key_event) {
-        *index = max_items - 1;
-        EventResult::Consumed
-    } else if theme.down_keys.iter().any(|f| f.is_pressed(key_event)) {
-        if max_items == 0 {
-            return EventResult::Ignored;
+    match KeyBindings::from_event(theme, key_event) {
+        KeyBindings::MoveTop => {
+            *index = 0;
+            EventResult::Consumed
         }
-        *index = (*index + 1).rem_euclid(max_items);
-        EventResult::Consumed
-    } else if theme.up_keys.iter().any(|f| f.is_pressed(key_event)) {
-        if max_items == 0 {
-            return EventResult::Ignored;
+        KeyBindings::MoveBottom => {
+            *index = max_items - 1;
+            EventResult::Consumed
         }
-        match index.checked_sub(1) {
-            Some(val) => *index = val,
-            None => *index = max_items - 1,
+        KeyBindings::DownKeys => {
+            if max_items == 0 {
+                return EventResult::Ignored;
+            }
+            *index = (*index + 1).rem_euclid(max_items);
+            EventResult::Consumed
         }
-        EventResult::Consumed
-    } else {
-        EventResult::Ignored
-    };
+        KeyBindings::UpKeys => {
+            if max_items == 0 {
+                return EventResult::Ignored;
+            }
+            match index.checked_sub(1) {
+                Some(val) => *index = val,
+                None => *index = max_items - 1,
+            }
+            EventResult::Consumed
+        }
+        _ => EventResult::Ignored,
+    }
 }
 
 pub fn handle_mouse_movement(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{KeyCode, KeyEvent, MouseEvent, MouseEventKind};
+use crossterm::event::{KeyEvent, MouseEvent, MouseEventKind};
 use tui::layout::{Constraint, Direction, Layout, Rect};
 
 use std::usize;
@@ -166,7 +166,7 @@ pub(crate) mod ui {
         Block::default()
             .title(title)
             .borders(Borders::ALL)
-            .border_type(app.theme.border_style.border_type)
+            .border_type(app.theme.border_style)
             .border_style(Style::default().fg(border_colour))
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -62,34 +62,30 @@ pub fn handle_key_movement(
     index: &mut usize,
     max_items: usize,
 ) -> EventResult {
-    match key_event.code {
-        _ if theme.move_top.is_pressed(key_event) => {
-            *index = 0;
-            EventResult::Consumed
+    return if theme.move_top.is_pressed(key_event) {
+        *index = 0;
+        EventResult::Consumed
+    } else if theme.move_bottom.is_pressed(key_event) {
+        *index = max_items - 1;
+        EventResult::Consumed
+    } else if theme.down_keys.iter().any(|f| f.is_pressed(key_event)) {
+        if max_items == 0 {
+            return EventResult::Ignored;
         }
-        _ if theme.move_bottom.is_pressed(key_event) => {
-            *index = max_items - 1;
-            EventResult::Consumed
+        *index = (*index + 1).rem_euclid(max_items);
+        EventResult::Consumed
+    } else if theme.up_keys.iter().any(|f| f.is_pressed(key_event)) {
+        if max_items == 0 {
+            return EventResult::Ignored;
         }
-        _ if theme.down_keys.iter().any(|f| f.is_pressed(key_event)) => {
-            if max_items == 0 {
-                return EventResult::Ignored;
-            }
-            *index = (*index + 1).rem_euclid(max_items);
-            EventResult::Consumed
+        match index.checked_sub(1) {
+            Some(val) => *index = val,
+            None => *index = max_items - 1,
         }
-        _ if theme.up_keys.iter().any(|f| f.is_pressed(key_event)) => {
-            if max_items == 0 {
-                return EventResult::Ignored;
-            }
-            match index.checked_sub(1) {
-                Some(val) => *index = val,
-                None => *index = max_items - 1,
-            }
-            EventResult::Consumed
-        }
-        _ => EventResult::Ignored,
-    }
+        EventResult::Consumed
+    } else {
+        EventResult::Ignored
+    };
 }
 
 pub fn handle_mouse_movement(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -40,11 +40,17 @@ fn centre_constraints(constraint: Constraint, rect_bound: u16) -> [Constraint; 3
             Constraint::Ratio(num, den),
             Constraint::Ratio((den - num) / 2, den),
         ],
-        Constraint::Length(length) => [
-            Constraint::Length((rect_bound - length) / 2),
-            Constraint::Length(length),
-            Constraint::Length((rect_bound - length) / 2),
-        ],
+        Constraint::Length(length) => {
+            let var = match rect_bound.checked_sub(length) {
+                Some(var) => var / 2,
+                _ => 0,
+            };
+            [
+                Constraint::Length(var),
+                Constraint::Length(length),
+                Constraint::Length(var),
+            ]
+        }
         _ => [constraint, constraint, constraint],
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,9 @@
-use crossterm::event::{KeyCode, MouseEvent, MouseEventKind};
+use crossterm::event::{KeyCode, KeyEvent, MouseEvent, MouseEventKind};
 use tui::layout::{Constraint, Direction, Layout, Rect};
 
 use std::usize;
 
+use crate::theme::Theme;
 use crate::{
     app::{App, Mode},
     draw::EventResult,
@@ -55,24 +56,29 @@ fn centre_constraints(constraint: Constraint, rect_bound: u16) -> [Constraint; 3
     }
 }
 
-pub fn handle_key_movement(key_code: KeyCode, index: &mut usize, max_items: usize) -> EventResult {
-    match key_code {
-        KeyCode::Char('g') => {
+pub fn handle_key_movement(
+    theme: &Theme,
+    key_event: KeyEvent,
+    index: &mut usize,
+    max_items: usize,
+) -> EventResult {
+    match key_event.code {
+        _ if theme.move_top.is_pressed(key_event) => {
             *index = 0;
             EventResult::Consumed
         }
-        KeyCode::Char('G') => {
+        _ if theme.move_bottom.is_pressed(key_event) => {
             *index = max_items - 1;
             EventResult::Consumed
         }
-        KeyCode::Down | KeyCode::Char('j') => {
+        _ if theme.down_keys.iter().any(|f| f.is_pressed(key_event)) => {
             if max_items == 0 {
                 return EventResult::Ignored;
             }
             *index = (*index + 1).rem_euclid(max_items);
             EventResult::Consumed
         }
-        KeyCode::Up | KeyCode::Char('k') => {
+        _ if theme.up_keys.iter().any(|f| f.is_pressed(key_event)) => {
             if max_items == 0 {
                 return EventResult::Ignored;
             }


### PR DESCRIPTION
Adds the ability to customise Keyboard shortcuts and allow HEX or index colours to select a particular colour.

Things that still need to be done:
- [x] Update help menus
- [ ] Consider if input options such as DialogBox should also allow customisable keyboard shortcuts.

This currently uses a `KeyBindings` enum for all the possible Keys, this kinda adds verboseness, but makes the code more readable by allowing a match statement instead of if else's. Something to consider in the future.